### PR TITLE
Add support for Rails 5.2

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -210,7 +210,8 @@ module ActionView
               options[:include_blank] ||= true unless options[:prompt]
             end
 
-            value = options[:selected] ? options[:selected] : value(object)
+            object_value = Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2 ? value : value(object)
+            value = options[:selected] ? options[:selected] : object_value
             priority_regions = options[:priority] || []
             opts = add_options(region_options_for_select(parent_region.subregions, value, 
                                                         :priority => priority_regions), 


### PR DESCRIPTION
Jira ticket [STOR-6713](https://sparefoot.atlassian.net/browse/STOR-6713)

## Purpose
Rails 5.2 changed `ActionView::Helpers::Tags::Base#value` to no longer accept an `object` parameter (https://github.com/rails/rails/pull/29791) causing the following error:
```
ActionView::Template::Error: wrong number of arguments (given 1, expected 0)
```

## Notable changes
Anything you feel needs to be called out about this change.

## Areas to test
Specific parts of the app you would like someone to test. (if necessary)

## Merge Checklist:

- [ ] Check for any tests that should be written
- [ ] Check for any necessary Cubesmart translations
- [ ] Perform a self-review of your code
- [ ] Make sure your changes meet all of the acceptance criteria
- [ ] Ask the Reporter of this ticket if they would like a Demo
- [ ] Squash unnecessary commits and make sure you have good commit messages
- [ ] Update doc/features with your new change for newbs
